### PR TITLE
added meta for highlight in numbers issue

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -112,6 +112,7 @@ const MyApp = ({ Component, pageProps }) => {
           name="description"
           content="Le damos la posibilidad a empresas de crear eventos virtuales con el objetivo de potenciar el clima laboral."
         />
+        <meta name="format-detection" content="telephone=no"/>
         <link rel="shortcut icon" href={`${config.storageUrl}/resources/icons/icon-72x72.png`} />
         <link rel="shortcut icon" href={`${config.storageUrl}/resources/icons/icon-512x512.png`} />
         <link


### PR DESCRIPTION
source: https://stackoverflow.com/questions/3736807/how-do-i-remove-the-blue-styling-of-telephone-numbers-on-iphone-ios